### PR TITLE
include borg.localrole-derived role assignments on sharing tab

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 2.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Include roles derived from borg.localrole adapters on the Sharing tab,
+  appearing as inherited roles.
+  [datakurre, davisagli]
 
 
 2.1.3 (2013-04-29)


### PR DESCRIPTION
This makes local role assignments obtained from borg.localrole adapters show up on the Sharing tab as inherited roles.

The work is adapted from @datakurre's code: http://webcache.googleusercontent.com/search?q=cache:18h4krMP8_UJ:lists.plone.org/pipermail/plone-product-developers/2012-December/011958.html+&cd=1&hl=en&ct=clnk&gl=us

If this looks acceptable we need to merge it to master too, which I can help with.
