### PR TITLE
Remove usage of 'Change portal events' permission

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Remove usage of 'Change portal events' permission.
+  [gforcada]
 
 
 2.2.7 (2017-02-12)

--- a/plone/app/workflow/tests/test_one_state_workflow.py
+++ b/plone/app/workflow/tests/test_one_state_workflow.py
@@ -4,7 +4,6 @@ from Products.CMFCore.utils import _checkPermission as checkPerm
 from Products.CMFCore.permissions import AccessContentsInformation
 from Products.CMFCore.permissions import View
 from Products.CMFCore.permissions import ModifyPortalContent
-ChangeEvents = 'Change portal events'
 
 
 class TestOneStateWorkflow(WorkflowTestCase):
@@ -103,31 +102,6 @@ class TestOneStateWorkflow(WorkflowTestCase):
         # Reader is denied
         self.login('reader')
         self.assertFalse(checkPerm(ModifyPortalContent, self.doc))
-
-    # Check change events permission
-
-    def testChangeEventsIsNotAcquiredInPublishedState(self):
-        # since r104169 event content doesn't use `ChangeEvents` anymore...
-        self.assertEqual(self.ni.acquiredRolesAreUsedBy(ModifyPortalContent), '')
-
-    def testModifyPublishEvent(self):
-        # Owner is allowed
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Member is denied
-        self.login('member')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Reviewer is denied
-        self.login('reviewer')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Anonymous is denied
-        self.logout()
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Editor is allowed
-        self.login('editor')
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Reader is denied
-        self.login('reader')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
 
 
 def test_suite():

--- a/plone/app/workflow/tests/test_plone_workflow.py
+++ b/plone/app/workflow/tests/test_plone_workflow.py
@@ -5,7 +5,6 @@ from Products.CMFCore.utils import _checkPermission as checkPerm
 from Products.CMFCore.permissions import AccessContentsInformation
 from Products.CMFCore.permissions import View
 from Products.CMFCore.permissions import ModifyPortalContent
-ChangeEvents = 'Change portal events'
 
 
 class TestDefaultWorkflow(WorkflowTestCase):
@@ -337,65 +336,6 @@ class TestDefaultWorkflow(WorkflowTestCase):
         self.login('reviewer')
         self.workflow.doActionFor(self.doc, 'publish')
         self.assertEqual(self.doc.acquiredRolesAreUsedBy(ModifyPortalContent), '')
-
-    # Check change events permission
-
-    def testModifyVisibleEvent(self):
-        # Owner is allowed
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Member is denied
-        self.login('member')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Reviewer is denied
-        self.login('reviewer')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Anonymous is denied
-        self.logout()
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-
-    def testModifyPrivateEvent(self):
-        self.workflow.doActionFor(self.ni, 'hide')
-        # Owner is allowed
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Member is denied
-        self.login('member')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Reviewer is denied
-        self.login('reviewer')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Anonymous is denied
-        self.logout()
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-
-    def testModifyPendingEvent(self):
-        self.workflow.doActionFor(self.ni, 'submit')
-        # Owner is denied
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Member is denied
-        self.login('member')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Reviewer is allowed
-        self.login('reviewer')
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Anonymous is denied
-        self.logout()
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-
-    def testModifyPublishedEvent(self):
-        self.login('reviewer')
-        self.workflow.doActionFor(self.ni, 'publish')
-        # Owner is denied
-        self.login(TEST_USER_NAME)
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Member is denied
-        self.login('member')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Reviewer is denied
-        self.login('reviewer')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Anonymous is denied
-        self.logout()
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
 
     # Check catalog search
 

--- a/plone/app/workflow/tests/test_simple_publication_workflow.py
+++ b/plone/app/workflow/tests/test_simple_publication_workflow.py
@@ -5,7 +5,6 @@ from Products.CMFCore.utils import _checkPermission as checkPerm
 from Products.CMFCore.permissions import AccessContentsInformation
 from Products.CMFCore.permissions import View
 from Products.CMFCore.permissions import ModifyPortalContent
-ChangeEvents = 'Change portal events'
 
 
 class TestSimplePublicationWorkflow(WorkflowTestCase):
@@ -207,53 +206,6 @@ class TestSimplePublicationWorkflow(WorkflowTestCase):
         # Reader is denied
         self.login('reader')
         self.assertFalse(checkPerm(ModifyPortalContent, self.doc))
-
-    # Check change events permission
-
-    def testModifyPrivateEvent(self):
-        self.assertEqual(self.workflow.getInfoFor(self.ni, 'review_state'), 'private')
-        # Owner is allowed
-        self.login(TEST_USER_NAME)
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Member is denied
-        self.login('member')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Reviewer is denied
-        self.login('reviewer')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Anonymous is denied
-        self.logout()
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Editor is allowed
-        self.login('editor')
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Reader is denied
-        self.login('reader')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-
-    def testModifyPublishEvent(self):
-        # transition requires Review portal content
-        self.login('manager')
-        self.workflow.doActionFor(self.ni, 'publish')
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Owner is allowed
-        self.login(TEST_USER_NAME)
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Member is denied
-        self.login('member')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Reviewer is denied
-        self.login('reviewer')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Anonymous is denied
-        self.logout()
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
-        # Editor is allowed
-        self.login('editor')
-        self.assertTrue(checkPerm(ChangeEvents, self.ni))
-        # Reader is denied
-        self.login('reader')
-        self.assertFalse(checkPerm(ChangeEvents, self.ni))
 
 
 def test_suite():


### PR DESCRIPTION
Part of the fix of https://github.com/plone/Products.CMFPlone/issues/1975