### PR TITLE
Python 3 and GenericSetup 2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,9 @@ Breaking changes:
 - No need to define cmf.ChangeLocalRoles in zcml since this is in by Products.CMFCore>=2.4.0b2
   [jensens]
 
-- No need to define cmf.ChangeLocalRoles in zcml since this is in by Products.CMFCore>=2.4.0b2
-  [jensens]
+- Adapt tests to `Products.GenericSetup >= 2.0` thus requiring at least that
+  version.
+  [jessesnyder]
 
 New features:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Python3 compatibility
+  [jessesnyder, pbauer]
 
 Bug fixes:
 

--- a/plone/app/workflow/exportimport.py
+++ b/plone/app/workflow/exportimport.py
@@ -1,3 +1,4 @@
+import six
 from persistent import Persistent
 from zope.interface import implementer
 
@@ -16,7 +17,6 @@ from Products.GenericSetup.utils import XMLAdapterBase
 
 from zope.i18nmessageid import MessageFactory
 PMF = MessageFactory('plone')
-
 
 
 @implementer(ISharingPageRole)
@@ -68,7 +68,7 @@ class SharingXMLAdapter(XMLAdapterBase):
     def _iterRoleRegistrations(self):
         for reg in tuple(self.context.registeredUtilities()):
             if reg.provided.isOrExtends(ISharingPageRole) \
-                    and isinstance(reg.info, basestring)  \
+                    and isinstance(reg.info, six.string_types)  \
                     and self.info_tag in reg.info:
                 yield reg
 
@@ -81,8 +81,8 @@ class SharingXMLAdapter(XMLAdapterBase):
         if node.nodeName != 'role':
             return
 
-        name = unicode(node.getAttribute('id'))
-        title = unicode(node.getAttribute('title'))
+        name = six.text_type(node.getAttribute('id'))
+        title = six.text_type(node.getAttribute('title'))
         required = node.getAttribute('permission') or None
         iface = node.getAttribute('interface') or None
         if iface is not None:

--- a/plone/app/workflow/permissions.py
+++ b/plone/app/workflow/permissions.py
@@ -1,26 +1,42 @@
-from Products.CMFCore.permissions import setDefaultRoles
+# -*- coding: utf-8 -*-
 from AccessControl import ModuleSecurityInfo
+from AccessControl.Permission import addPermission
 
 security = ModuleSecurityInfo("plone.app.workflow.permissions")
 
 # Controls access to the "sharing" page
 security.declarePublic("DelegateRoles")
 DelegateRoles = "Sharing page: Delegate roles"
-setDefaultRoles(DelegateRoles, ('Manager', 'Site Administrator', 'Owner', 'Editor', 'Reviewer', ))
+addPermission(
+    DelegateRoles,
+    ('Manager', 'Site Administrator', 'Owner', 'Editor', 'Reviewer', ),
+)
 
 # Control the individual roles
 security.declarePublic("DelegateReaderRole")
 DelegateReaderRole = "Sharing page: Delegate Reader role"
-setDefaultRoles(DelegateReaderRole, ('Manager', 'Site Administrator', 'Owner', 'Editor', 'Reviewer'))
+addPermission(
+    DelegateReaderRole,
+    ('Manager', 'Site Administrator', 'Owner', 'Editor', 'Reviewer'),
+)
 
 security.declarePublic("DelegateEditorRole")
 DelegateEditorRole = "Sharing page: Delegate Editor role"
-setDefaultRoles(DelegateEditorRole, ('Manager', 'Site Administrator', 'Owner', 'Editor'))
+addPermission(
+    DelegateEditorRole,
+    ('Manager', 'Site Administrator', 'Owner', 'Editor'),
+)
 
 security.declarePublic("DelegateContributorRole")
 DelegateContributorRole = "Sharing page: Delegate Contributor role"
-setDefaultRoles(DelegateContributorRole, ('Manager', 'Site Administrator', 'Owner',))
+addPermission(
+    DelegateContributorRole,
+    ('Manager', 'Site Administrator', 'Owner',),
+)
 
 security.declarePublic("DelegateReviewerRole")
 DelegateReviewerRole = "Sharing page: Delegate Reviewer role"
-setDefaultRoles(DelegateReviewerRole, ('Manager', 'Site Administrator', 'Reviewer',))
+addPermission(
+    DelegateReviewerRole,
+    ('Manager', 'Site Administrator', 'Reviewer',),
+)

--- a/plone/app/workflow/tests/sharingpage.rst
+++ b/plone/app/workflow/tests/sharingpage.rst
@@ -37,7 +37,7 @@ We shouldn't see the Sharing tab
     >>> browser.getLink('Sharing')
     Traceback (most recent call last):
     ...
-    LinkNotFoundError
+    zope.testbrowser.browser.LinkNotFoundError
 
 Manager
 -------
@@ -157,7 +157,7 @@ Sharing tab.
     >>> browser.getLink('Sharing')
     Traceback (most recent call last):
     ...
-    LinkNotFoundError
+    zope.testbrowser.browser.LinkNotFoundError
 
 Delegated Editor
 ----------------
@@ -198,7 +198,7 @@ A delegated Contributor cannot assign any further rights.
     >>> browser.getLink('Sharing').click()
     Traceback (most recent call last):
     ...
-    LinkNotFoundError
+    zope.testbrowser.browser.LinkNotFoundError
 
 Delegated Reviewer
 ------------------

--- a/plone/app/workflow/tests/test_exportimport.py
+++ b/plone/app/workflow/tests/test_exportimport.py
@@ -319,14 +319,14 @@ class TestExport(ExportImportTest):
 
     def test_export_empty(self):
 
-        xml = """\
-<?xml version="1.0"?>
+        xml = b"""\
+<?xml version="1.0" encoding="utf-8"?>
 <sharing/>
 """
         context = DummyExportContext(self.site)
         export_sharing(context)
 
-        self.assertEqual('sharing.xml', context._wrote[0][0])
+        self.assertEqual(u'sharing.xml', context._wrote[0][0])
         self.assertEqual(xml, context._wrote[0][1])
 
     def test_export_multiple(self):
@@ -338,7 +338,7 @@ class TestExport(ExportImportTest):
         # Will not be exported, as it wasn't imported with this handler
         sm.registerUtility(PersistentSharingPageRole("Do other Stuff"), ISharingPageRole, "DoerOfOtherStuff")
 
-        import_xml = """\
+        import_xml = b"""\
 <sharing>
  <role title="Can control" id="Controller"/>
  <role title="Can copyedit" id="CopyEditor"
@@ -346,8 +346,8 @@ class TestExport(ExportImportTest):
 </sharing>
 """
 
-        export_xml = """\
-<?xml version="1.0"?>
+        export_xml = b"""\
+<?xml version="1.0" encoding="utf-8"?>
 <sharing>
  <role title="Can control" id="Controller"/>
  <role title="Can copyedit" id="CopyEditor"

--- a/plone/app/workflow/tests/test_functional.py
+++ b/plone/app/workflow/tests/test_functional.py
@@ -8,6 +8,8 @@ from plone.testing import layered
 from Products.CMFCore.utils import getToolByName
 
 import doctest
+import re
+import six
 import transaction
 import unittest
 
@@ -37,6 +39,13 @@ def setup(doctest):
     transaction.commit()
 
 
+class Py23DocChecker(doctest.OutputChecker):
+    def check_output(self, want, got, optionflags):
+        if six.PY2:
+            want = re.sub('zope.testbrowser.browser.LinkNotFoundError', 'LinkNotFoundError', want)  # noqa: E501
+        return doctest.OutputChecker.check_output(self, want, got, optionflags)
+
+
 def test_suite():
     suite = unittest.TestSuite()
     tests = [
@@ -46,6 +55,7 @@ def test_suite():
                 package='plone.app.workflow',
                 optionflags=optionflags,
                 setUp=setup,
+                checker=Py23DocChecker(),
             ),
             layer=PLONE_APP_WORKFLOW_FUNCTIONAL_TESTING,
         )

--- a/plone/app/workflow/tests/test_sharing_view.py
+++ b/plone/app/workflow/tests/test_sharing_view.py
@@ -90,7 +90,7 @@ class TestSharingView(unittest.TestCase):
         self.assertTrue(len(results))
         self.assertEqual(
             results[-1].get('title'),
-            '\xc3\x84\xc3\x9c\xc3\x9f',
+            b'\xc3\x84\xc3\x9c\xc3\x9f',
             msg="Umlaute",
         )
 

--- a/plone/app/workflow/tests/test_sharing_view.py
+++ b/plone/app/workflow/tests/test_sharing_view.py
@@ -31,7 +31,7 @@ class TestSharingView(unittest.TestCase):
         testuser = self.portal.portal_membership.getMemberById('testuser')
         testuser.setMemberProperties(dict(email='testuser@plone.org'))
         nonasciiuser = self.portal.portal_membership.getMemberById('nonasciiuser')
-        nonasciiuser.setMemberProperties(dict(fullname=u'\xc4\xdc\xdf'.encode('utf-8')))
+        nonasciiuser.setMemberProperties(dict(fullname=u'\xc4\xdc\xdf'))
         login(self.portal, 'manager')
 
     def test_search_by_login_name(self):

--- a/plone/app/workflow/tests/test_sharing_view.py
+++ b/plone/app/workflow/tests/test_sharing_view.py
@@ -13,6 +13,7 @@ from zope.event import notify
 from zope.interface import implementer
 from zope.interface import Interface
 
+import six
 import unittest
 
 
@@ -88,9 +89,12 @@ class TestSharingView(unittest.TestCase):
         view = getMultiAdapter((self.portal, self.request), name='sharing')
         results = view.role_settings()
         self.assertTrue(len(results))
+        expected = u'ÄÜß'
+        if six.PY2:
+            expected = expected.encode('utf8')
         self.assertEqual(
             results[-1].get('title'),
-            b'\xc3\x84\xc3\x9c\xc3\x9f',
+            expected,
             msg="Umlaute",
         )
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'Products.CMFPlone',
         'Products.CMFCore>=2.4.0dev',
         'Products.DCWorkflow',
-        'Products.GenericSetup',
+        'Products.GenericSetup >= 2.0.dev0',
         'Products.statusmessages',
         'Zope2',
     ],

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Acquisition',
         'DateTime',
         'Products.CMFPlone',
-        'Products.CMFCore>=2.4.0b2',
+        'Products.CMFCore>=2.4.0dev',
         'Products.DCWorkflow',
         'Products.GenericSetup',
         'Products.statusmessages',

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     keywords='workflow sharing plone',
     author='Plone Foundation',
@@ -35,6 +37,7 @@ setup(
     install_requires=[
         'setuptools',
         'plone.memoize',
+        'six',
         'transaction',
         'zope.component',
         'zope.dottedname',


### PR DESCRIPTION
This is needed to get Plone 5.2 coredev buildout green again. After the Python 3 changes of `Products.GenericSetup` have been merged to master.