### PR TITLE
Fix wrong msgid in button translation

### DIFF
--- a/news/33.bugfix
+++ b/news/33.bugfix
@@ -1,0 +1,2 @@
+Fix translation of `sharing` buttons.
+[petschki]

--- a/plone/app/workflow/browser/sharing.pt
+++ b/plone/app/workflow/browser/sharing.pt
@@ -161,11 +161,11 @@
                                 class="btn btn-primary"
                                 type="submit"
                                 name="form.button.Save"
-                                i18n:translate="value label_save">Save</button>
+                                i18n:translate="label_save">Save</button>
                         <button class="btn btn-secondary"
                                 type="submit"
                                 name="form.button.Cancel"
-                                i18n:translate="value label_cancel">Cancel</button>
+                                i18n:translate="label_cancel">Cancel</button>
                         <input tal:replace="structure context/@@authenticator/authenticator" />
                     </form>
                 </div>


### PR DESCRIPTION
This is probably due to the change from `<input type="button" />` to `<button />` ... the `label_save` and `label_cancel` are already translated ...

@erral can you give me some insights, how to recreate POT and PO files in `plone.app.locales` ?