### PR TITLE
21 typeerror not supported between instances of dict and dict

### DIFF
--- a/news/21.bugfix
+++ b/news/21.bugfix
@@ -1,0 +1,2 @@
+Fix ``TypeError`` in the sharing view when two role entries tie on
+``(sticky, type, name)``; [jmevissen]

--- a/src/plone/app/workflow/browser/sharing.py
+++ b/src/plone/app/workflow/browser/sharing.py
@@ -285,7 +285,10 @@ class SharingView(BrowserView):
             (a["id"] not in self.STICKY, a["type"], a["name"], a)
             for a in items.values()
         ]
-        dec_users.sort()
+        # Sort only on the first three entries,
+        # the fourth is a dict and would raise a TypeError
+        # see plone/plone.app.workflow#21
+        dec_users.sort(key=lambda d: (d[0], d[1], d[2]))
 
         # Add the items to the info dict, assigning full name if possible.
         # Also, recut roles in the format specified in the docstring

--- a/src/plone/app/workflow/tests/test_sharing_view.py
+++ b/src/plone/app/workflow/tests/test_sharing_view.py
@@ -234,3 +234,26 @@ class TestSharingView(unittest.TestCase):
         # check subscriber called
         self.assertEqual(context.context, context)
         self.assertEqual(context.event, event)
+
+    def test_existing_role_settings_sort_with_duplicate_names(self):
+        """Regression test for plone/plone.app.workflow#21.
+
+        When two entries tie on (sticky, type, name), the old
+        ``dec_users.sort()`` fell through to comparing the item dicts at
+        index 3, raising ``TypeError: '<' not supported between instances
+        of 'dict' and 'dict'`` on Python 3.
+        """
+        login(self.portal, "manager")
+        sharing = getMultiAdapter((self.portal, self.request), name="sharing")
+
+        def fake_inherited_roles():
+            return (
+                ("shared_name", ("Reader",), "user", "user_a"),
+                ("shared_name", ("Reader",), "user", "user_b"),
+            )
+
+        sharing._inherited_roles = fake_inherited_roles
+        info = sharing.existing_role_settings()
+        ids = {entry["id"] for entry in info}
+        self.assertIn("user_a", ids)
+        self.assertIn("user_b", ids)


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #21 

